### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility

### DIFF
--- a/DeBERTa/apps/_utils.py
+++ b/DeBERTa/apps/_utils.py
@@ -1,5 +1,6 @@
 import torch
-from collections import OrderedDict, Mapping, Sequence
+from collections import OrderedDict
+from collections.abc import Mapping, Sequence
 
 def merge_distributed(data_list, max_len=None):
   if torch.distributed.is_initialized() and torch.distributed.get_world_size()>1:

--- a/DeBERTa/apps/run.py
+++ b/DeBERTa/apps/run.py
@@ -12,7 +12,8 @@
 import os
 os.environ["OMP_NUM_THREADS"] = "1"
 from ..deberta import tokenizers,load_vocab
-from collections import OrderedDict, Mapping, Sequence
+from collections import OrderedDict
+from collections.abc import Mapping, Sequence
 import argparse
 import random
 import time

--- a/DeBERTa/apps/tasks/glue_tasks.py
+++ b/DeBERTa/apps/tasks/glue_tasks.py
@@ -8,7 +8,8 @@
 #
 
 from glob import glob
-from collections import OrderedDict,defaultdict,Sequence
+from collections import OrderedDict,defaultdict
+from collections.abc import Sequence
 import copy
 import math
 from scipy.special import softmax

--- a/DeBERTa/apps/tasks/mlm_task.py
+++ b/DeBERTa/apps/tasks/mlm_task.py
@@ -4,7 +4,8 @@
 #
 
 from glob import glob
-from collections import OrderedDict,defaultdict,Sequence
+from collections import OrderedDict,defaultdict
+from collections.abc import Sequence
 from bisect import bisect
 import copy
 import math

--- a/DeBERTa/apps/tasks/ner_task.py
+++ b/DeBERTa/apps/tasks/ner_task.py
@@ -1,5 +1,6 @@
 
-from collections import OrderedDict,defaultdict,Sequence,Counter
+from collections import OrderedDict,defaultdict,Counter
+from collections.abc import Sequence
 import math
 import numpy as np
 import os

--- a/DeBERTa/apps/tasks/race_task.py
+++ b/DeBERTa/apps/tasks/race_task.py
@@ -4,7 +4,8 @@
 #
 
 from glob import glob
-from collections import OrderedDict,defaultdict,Sequence
+from collections import OrderedDict,defaultdict
+from collections.abc import Sequence
 import copy
 import math
 from scipy.special import softmax

--- a/DeBERTa/apps/tasks/superglue_tasks.py
+++ b/DeBERTa/apps/tasks/superglue_tasks.py
@@ -8,7 +8,8 @@
 #
 
 from glob import glob
-from collections import OrderedDict,defaultdict,Sequence,Counter
+from collections import OrderedDict,defaultdict,Counter
+from collections.abc import Sequence
 import copy
 import math
 import string

--- a/DeBERTa/apps/tasks/task.py
+++ b/DeBERTa/apps/tasks/task.py
@@ -6,7 +6,8 @@
 import os
 import csv
 import copy
-from collections import OrderedDict,defaultdict,Sequence,Counter
+from collections import OrderedDict,defaultdict,Counter
+from collections.abc import Sequence
 import numpy as np
 from ...utils import get_logger
 from ...utils import xtqdm as tqdm

--- a/DeBERTa/data/dataloader.py
+++ b/DeBERTa/data/dataloader.py
@@ -14,7 +14,7 @@ else:
 from torch.utils.data import SequentialSampler, RandomSampler, BatchSampler, Sampler
 import signal
 import functools
-import collections
+import collections.abc
 import re
 import sys
 import threading
@@ -187,9 +187,9 @@ def default_collate(batch):
         return torch.DoubleTensor(batch)
     elif isinstance(batch[0], string_classes):
         return batch
-    elif isinstance(batch[0], collections.Mapping):
+    elif isinstance(batch[0], collections.abc.Mapping):
         return {key: default_collate([d[key] for d in batch]) for key in batch[0]}
-    elif isinstance(batch[0], collections.Sequence):
+    elif isinstance(batch[0], collections.abc.Sequence):
         transposed = zip(*batch)
         return [default_collate(samples) for samples in transposed]
 
@@ -201,9 +201,9 @@ def pin_memory_batch(batch):
         return batch.pin_memory()
     elif isinstance(batch, string_classes):
         return batch
-    elif isinstance(batch, collections.Mapping):
+    elif isinstance(batch, collections.abc.Mapping):
         return {k: pin_memory_batch(sample) for k, sample in batch.items()}
-    elif isinstance(batch, collections.Sequence):
+    elif isinstance(batch, collections.abc.Sequence):
         return [pin_memory_batch(sample) for sample in batch]
     else:
         return batch

--- a/DeBERTa/deberta/bert.py
+++ b/DeBERTa/deberta/bert.py
@@ -9,7 +9,7 @@
 import copy
 import torch
 from torch import nn
-from collections import Sequence
+from collections.abc import Sequence
 from packaging import version
 import numpy as np
 import math

--- a/DeBERTa/training/_utils.py
+++ b/DeBERTa/training/_utils.py
@@ -1,5 +1,5 @@
 import torch
-from collections import Sequence, Mapping
+from collections.abc import Sequence, Mapping
 
 def batch_apply(batch, fn):
   if isinstance(batch, torch.Tensor):

--- a/DeBERTa/training/trainer.py
+++ b/DeBERTa/training/trainer.py
@@ -12,7 +12,8 @@ import random
 import time
 import numpy as np
 import pdb
-from collections import defaultdict, Mapping, Sequence, OrderedDict
+from collections import defaultdict, OrderedDict
+from collections.abc import Mapping, Sequence
 from torch.utils.data import DataLoader
 from ..data import BatchSampler, DistributedBatchSampler,RandomSampler,SequentialSampler, AsyncDataLoader
 from ..utils import get_logger

--- a/experiments/my_exp/alpha_nli.py
+++ b/experiments/my_exp/alpha_nli.py
@@ -4,7 +4,8 @@
 #
 
 from glob import glob
-from collections import OrderedDict,defaultdict,Sequence
+from collections import OrderedDict,defaultdict
+from collections.abc import Sequence
 import copy
 import math
 from scipy.special import softmax

--- a/experiments/my_exp/race_task.py
+++ b/experiments/my_exp/race_task.py
@@ -4,7 +4,8 @@
 #
 
 from glob import glob
-from collections import OrderedDict,defaultdict,Sequence
+from collections import OrderedDict,defaultdict
+from collections.abc import Sequence
 import copy
 import math
 from scipy.special import softmax


### PR DESCRIPTION
Import ABC from `collections` was deprecated and removed in Python 3.10. Use `collections.abc` .