### PR TITLE
Change from deprecated package name sklearn to correct scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy
 pytest
 regex
 scipy
-sklearn
+scikit-learn
 tqdm
 ujson
 seqeval


### PR DESCRIPTION
The `requirements.txt` file lists `sklearn` as a dependency. Although this is the import name for the python package, the package's full name is `scikit-learn`. Specifying `sklearn` as a dependency leads to an error at installation time if install is attempted during specific time windows. See here for more info: https://github.com/scikit-learn/sklearn-pypi-package

This PR changes the requirements file to use `scikit-learn` instead of `sklearn`.