### PR TITLE
fix: Corrected code instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ class MyModel(torch.nn.Module):
     #   - If it's an attention mask then if will be torch.LongTensor of shape [batch_size, sequence_length, sequence_length]. 
     #      In this case, it's a mask indicating which tokens in the sequence should be attended by other tokens in the sequence. 
     # `output_all_encoded_layers`: whether to output results of all encoder layers, default, True
-    encoding = deberta.bert(input_ids)[-1]
+    encoding = self.deberta(input_ids)[-1]
 
 # 2. Change your tokenizer with the tokenizer built-in DeBERta
 from DeBERTa import deberta


### PR DESCRIPTION
In the README file, corrected an error in the usage instructions for conducting forward passes with DeBERTa. The previous instructions contained inaccuracies that could lead to misinterpretation and improper utilization of DeBERTa's forward pass functionality. This fix ensures that users can now accurately employ DeBERTa for forward passes.