### PR TITLE
sklearn changed to scikit-learn to avoid pip install failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy
 pytest
 regex
 scipy
-sklearn
+scikit-learn
 tqdm
 ujson
 seqeval


### PR DESCRIPTION
requirements.txt file contains 'sklearn' which should be corrected to package name 'scikit-learn' in order to avoid pip installation failure